### PR TITLE
Acquire yoloxl graph

### DIFF
--- a/onnx2torch/node_converters/reshape.py
+++ b/onnx2torch/node_converters/reshape.py
@@ -48,9 +48,11 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     if node.attributes.get('allowzero', 0) == 1:
         raise NotImplementedError('"allowzero=1" is not implemented')
     
-    try:
-        shape = get_const_value(node.input_values[1], graph).tolist()
-    except:
+    param_name = node.input_values[1]
+
+    if param_name in graph.initializers or param_name in graph._node_output_values:
+        shape = get_const_value(param_name, graph).tolist()
+    else:
         shape = []
 
     return OperationConverterResult(

--- a/onnx2torch/node_converters/reshape.py
+++ b/onnx2torch/node_converters/reshape.py
@@ -19,7 +19,7 @@ class OnnxReshape(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disa
     def __init__(self, shape: np.ndarray):
         super().__init__()
         self.shape = shape
-        
+
     @staticmethod
     def _do_reshape(input_tensor: torch.Tensor, shape: np.ndarray) -> torch.Tensor:
         if any(x == 0 for x in shape):
@@ -48,6 +48,6 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         raise NotImplementedError('"allowzero=1" is not implemented')
 
     return OperationConverterResult(
-        torch_module=OnnxReshape(graph.initializers[node.input_values[1]].to_torch().tolist(),),
+        torch_module=OnnxReshape(graph.initializers[node.input_values[1]].to_torch().numpy(),),
         onnx_mapping=onnx_mapping_from_node(node=node),
     )

--- a/onnx2torch/node_converters/reshape.py
+++ b/onnx2torch/node_converters/reshape.py
@@ -2,7 +2,7 @@ __all__ = [
     'OnnxReshape',
 ]
 
-import numpy as np
+from typing import List
 import torch
 from torch import nn
 
@@ -10,18 +10,18 @@ from onnx2torch.node_converters.registry import add_converter
 from onnx2torch.onnx_graph import OnnxGraph
 from onnx2torch.onnx_node import OnnxNode
 from onnx2torch.utils.common import OperationConverterResult
-from onnx2torch.utils.common import onnx_mapping_from_node
+from onnx2torch.utils.common import onnx_mapping_from_node, get_const_value
 from onnx2torch.utils.custom_export_to_onnx import DefaultExportToOnnx
 from onnx2torch.utils.custom_export_to_onnx import OnnxToTorchModuleWithCustomExport
 
 
 class OnnxReshape(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disable=missing-class-docstring
-    def __init__(self, shape: np.ndarray):
+    def __init__(self, shape: List):
         super().__init__()
         self.shape = shape
 
     @staticmethod
-    def _do_reshape(input_tensor: torch.Tensor, shape: np.ndarray) -> torch.Tensor:
+    def _do_reshape(input_tensor: torch.Tensor, shape: List) -> torch.Tensor:
         if any(x == 0 for x in shape):
             shape = [input_tensor.shape[i] if dim_size == 0 else dim_size for i, dim_size in enumerate(shape)]
 
@@ -32,7 +32,8 @@ class OnnxReshape(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disa
         input_tensor: torch.Tensor,
         shape: torch.Tensor,
     ) -> torch.Tensor:
-        forward_lambda = lambda: self._do_reshape(input_tensor, self.shape)
+        shape = self.shape if self.shape else shape.tolist()
+        forward_lambda = lambda: self._do_reshape(input_tensor, shape)
 
         if torch.onnx.is_in_onnx_export():
             return DefaultExportToOnnx.export(forward_lambda, 'Reshape', input_tensor, shape, {})
@@ -46,8 +47,13 @@ class OnnxReshape(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disa
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     if node.attributes.get('allowzero', 0) == 1:
         raise NotImplementedError('"allowzero=1" is not implemented')
+    
+    try:
+        shape = get_const_value(node.input_values[1], graph).tolist()
+    except:
+        shape = []
 
     return OperationConverterResult(
-        torch_module=OnnxReshape(graph.initializers[node.input_values[1]].to_torch().numpy(),),
+        torch_module=OnnxReshape(shape),
         onnx_mapping=onnx_mapping_from_node(node=node),
     )

--- a/onnx2torch/node_converters/reshape.py
+++ b/onnx2torch/node_converters/reshape.py
@@ -32,8 +32,8 @@ class OnnxReshape(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disa
         input_tensor: torch.Tensor,
         shape: torch.Tensor,
     ) -> torch.Tensor:
-        shape = self.shape if self.shape else shape.tolist()
-        forward_lambda = lambda: self._do_reshape(input_tensor, shape)
+        shape_list = self.shape if self.shape else shape.tolist()
+        forward_lambda = lambda: self._do_reshape(input_tensor, shape_list)
 
         if torch.onnx.is_in_onnx_export():
             return DefaultExportToOnnx.export(forward_lambda, 'Reshape', input_tensor, shape, {})

--- a/onnx2torch/node_converters/resize.py
+++ b/onnx2torch/node_converters/resize.py
@@ -91,7 +91,7 @@ class OnnxResize(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class
 
         return torch.nn.functional.interpolate(
             input_tensor,
-            size=None,
+            size=sizes,
             scale_factor=scales,
             mode=torch_mode,
             align_corners=self.align_corners,

--- a/onnx2torch/node_converters/resize.py
+++ b/onnx2torch/node_converters/resize.py
@@ -172,9 +172,9 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     constant_params = []
     params_names = node.input_values[1:]
     for name in params_names:
-        try:
+        if name in graph.initializers or name in graph._node_output_values:
             constant_params.append(get_const_value(name, graph).tolist())
-        except KeyError:
+        else:
             constant_params.append([])
     constant_params = constant_params + (3 - len(constant_params)) * [[]]
 

--- a/onnx2torch/node_converters/resize.py
+++ b/onnx2torch/node_converters/resize.py
@@ -106,7 +106,7 @@ class OnnxResize(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class
 class OnnxResizeV10(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class-docstring
     def __init__(self, mode: str = 'nearest'):
         super().__init__()
-        self._resize = OnnxResize(mode=mode)
+        self._resize = OnnxResize(roi=[], scales=[], sizes=[], mode=mode)
 
     def forward(  # pylint: disable=missing-function-docstring
         self,

--- a/onnx2torch/node_converters/resize.py
+++ b/onnx2torch/node_converters/resize.py
@@ -63,10 +63,23 @@ class OnnxResize(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class
         input_tensor: torch.Tensor,
         roi: Optional[torch.Tensor] = None,
         scales: Optional[torch.Tensor] = None,
+        sizes: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         torch_mode = _onnx_mode_to_torch_mode(self.onnx_mode, input_tensor.dim() - 2)
         if not self.ignore_roi and roi is not None and roi.nelement() != 0:
             raise NotImplementedError('roi logic is not implemented.')
+
+        # Format of onnx scales and sizes is [n, c, d, h, w]
+        # But in torch only [d, h, w] (without batch and channel dimensions)
+        if sizes is not None:
+            if sizes.nelement() != 0:
+                sizes = sizes.tolist()
+                input_shape = list(input_tensor.shape)
+                if not self.ignore_bs_ch_size and input_shape[:2] != sizes[:2]:
+                    raise NotImplementedError('Pytorch\'s interpolate cannot resize channel or batch dimensions.')
+                sizes = sizes[2:]
+            else:
+                sizes = None
 
         if self.scales is not None:
             if self.scales.size != 0:

--- a/onnx2torch/node_converters/resize.py
+++ b/onnx2torch/node_converters/resize.py
@@ -69,7 +69,6 @@ class OnnxResize(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class
         scales: Optional[torch.Tensor] = None,
         sizes: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        breakpoint()
         roi = roi.tolist() if roi != None and not self.roi else self.roi
         scales = scales.tolist() if scales != None and not self.scales else self.scales
         sizes = sizes.tolist() if sizes != None and not self.sizes else self.sizes
@@ -94,7 +93,7 @@ class OnnxResize(nn.Module, OnnxToTorchModule):  # pylint: disable=missing-class
             scales = tuple(scales[2:])
         else:
             scales = None
-        breakpoint()
+
         return torch.nn.functional.interpolate(
             input_tensor,
             size=sizes,

--- a/onnx2torch/node_converters/slice.py
+++ b/onnx2torch/node_converters/slice.py
@@ -89,18 +89,12 @@ class OnnxSlice(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
         axes: Optional[torch.Tensor] = None,
         steps: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        def _forward(
-            input_tensor: torch.Tensor,
-            starts: torch.Tensor,
-            ends: torch.Tensor,
-            axes: Optional[torch.Tensor] = None,
-            steps: Optional[torch.Tensor] = None,
-        ):
-            starts = starts.tolist() if starts != None and not self.starts else self.starts
-            ends = ends.tolist() if ends != None and not self.ends else self.ends
-            axes = axes.tolist() if axes != None and not self.axes else self.axes
-            steps = steps.tolist() if steps != None and not self.steps else self.steps
-            flip_dims, pos_axes_slices, neg_axes_slices = _get_slices(starts, ends, axes, steps)
+        def _forward():
+            starts_list = starts.tolist() if starts != None and not self.starts else self.starts
+            ends_list = ends.tolist() if ends != None and not self.ends else self.ends
+            axes_list = axes.tolist() if axes != None and not self.axes else self.axes
+            steps_list = steps.tolist() if steps != None and not self.steps else self.steps
+            flip_dims, pos_axes_slices, neg_axes_slices = _get_slices(starts_list, ends_list, axes_list, steps_list)
             return _do_slice(input_tensor, flip_dims, pos_axes_slices, neg_axes_slices)
 
         if torch.onnx.is_in_onnx_export():
@@ -112,7 +106,7 @@ class OnnxSlice(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
 
             return DefaultExportToOnnx.export(_forward, 'Slice', *args, {})
         
-        return _forward(input_tensor, starts, ends, axes, steps)
+        return _forward()
 
 
 @add_converter(operation_type='Slice', version=9)

--- a/onnx2torch/node_converters/slice.py
+++ b/onnx2torch/node_converters/slice.py
@@ -137,8 +137,6 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
 
 
     return OperationConverterResult(
-        torch_module=OnnxSlice(
-            *constant_params
-        ),
+        torch_module=OnnxSlice(*constant_params),
         onnx_mapping=onnx_mapping_from_node(node),
     )

--- a/onnx2torch/node_converters/slice.py
+++ b/onnx2torch/node_converters/slice.py
@@ -128,9 +128,9 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     constant_params = []
     params_names = node.input_values[1:]
     for name in params_names:
-        try:
+        if name in graph.initializers or name in graph._node_output_values:
             constant_params.append(get_const_value(name, graph).tolist())
-        except KeyError:
+        else:
             constant_params.append([])
     constant_params = constant_params + (4 - len(constant_params)) * [[]]
 

--- a/onnx2torch/node_converters/slice.py
+++ b/onnx2torch/node_converters/slice.py
@@ -41,6 +41,7 @@ def _get_slices(
             start, end, step = -start - 1, -end - 1, -step
 
         slices[axis] = slice(start, end, step)
+
     pos_axes_slices = list(slices.get(a, slice(None, None)) for a in range(max(axes) + 1))
     neg_axes_slices = list(slices.get(a, slice(None, None)) for a in range(min(axes), 0))
 
@@ -118,10 +119,10 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
 def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
     return OperationConverterResult(
         torch_module=OnnxSlice(
-            graph.initializers[node.input_values[1]].to_torch().tolist(),
-            graph.initializers[node.input_values[2]].to_torch().tolist(),
-            graph.initializers[node.input_values[3]].to_torch().tolist(),
-            graph.initializers[node.input_values[4]].to_torch().tolist(),
+            graph.initializers[node.input_values[1]].to_torch().numpy(),
+            graph.initializers[node.input_values[2]].to_torch().numpy(),
+            graph.initializers[node.input_values[3]].to_torch().numpy(),
+            graph.initializers[node.input_values[4]].to_torch().numpy(),
         ),
         onnx_mapping=onnx_mapping_from_node(node),
     )

--- a/onnx2torch/node_converters/slice.py
+++ b/onnx2torch/node_converters/slice.py
@@ -105,7 +105,6 @@ class OnnxSlice(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
                 args.append(steps)
 
             return DefaultExportToOnnx.export(_forward, 'Slice', *args, {})
-        
         return _forward()
 
 

--- a/onnx2torch/node_converters/slice.py
+++ b/onnx2torch/node_converters/slice.py
@@ -27,10 +27,10 @@ def _get_slices(
     axes: List,
     steps: List,
 ) -> Tuple[List, List, List]:
-    if axes is None:
+    if not axes:
         axes = list(range(len(starts)))
 
-    if steps is None:
+    if not steps:
         steps = [1] * len(starts)
     
     slices = {}
@@ -89,12 +89,18 @@ class OnnxSlice(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
         axes: Optional[torch.Tensor] = None,
         steps: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        def _forward():
-            starts_list = starts.tolist() if starts != None and not self.starts else self.starts
-            ends_list = ends.tolist() if ends != None and not self.ends else self.ends
-            axes_list = axes.tolist() if axes != None and not self.axes else self.axes
-            steps_list = steps.tolist() if steps != None and not self.steps else self.steps
-            flip_dims, pos_axes_slices, neg_axes_slices = _get_slices(starts_list, ends_list, axes_list, steps_list)
+        def _forward(
+            input_tensor: torch.Tensor,
+            starts: torch.Tensor,
+            ends: torch.Tensor,
+            axes: Optional[torch.Tensor] = None,
+            steps: Optional[torch.Tensor] = None,
+        ):
+            starts = starts.tolist() if starts != None and not self.starts else self.starts
+            ends = ends.tolist() if ends != None and not self.ends else self.ends
+            axes = axes.tolist() if axes != None and not self.axes else self.axes
+            steps = steps.tolist() if steps != None and not self.steps else self.steps
+            flip_dims, pos_axes_slices, neg_axes_slices = _get_slices(starts, ends, axes, steps)
             return _do_slice(input_tensor, flip_dims, pos_axes_slices, neg_axes_slices)
 
         if torch.onnx.is_in_onnx_export():
@@ -106,7 +112,7 @@ class OnnxSlice(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: disabl
 
             return DefaultExportToOnnx.export(_forward, 'Slice', *args, {})
         
-        return _forward()
+        return _forward(input_tensor, starts, ends, axes, steps)
 
 
 @add_converter(operation_type='Slice', version=9)


### PR DESCRIPTION
Modified `reshape`, `resize`, `slice` to support acquiring the graph of yolo_xl onnx model on both CPU and GPU.