### PR TITLE
Add override for node_converter registry

### DIFF
--- a/onnx2torch2/node_converters/registry.py
+++ b/onnx2torch2/node_converters/registry.py
@@ -25,6 +25,7 @@ def add_converter(  # pylint: disable=missing-function-docstring
     operation_type: str,
     version: int,
     domain: str = defs.ONNX_DOMAIN,
+    override_registry: bool = False,
 ):
     description = OperationDescription(
         domain=domain,
@@ -33,7 +34,7 @@ def add_converter(  # pylint: disable=missing-function-docstring
     )
 
     def deco(converter: TConverter):
-        if description in _CONVERTER_REGISTRY:
+        if description in _CONVERTER_REGISTRY and not override_registry:
             raise ValueError(f'Operation "{description}" already registered')
 
         _CONVERTER_REGISTRY[description] = converter

--- a/onnx2torch2/utils/custom_export_to_onnx.py
+++ b/onnx2torch2/utils/custom_export_to_onnx.py
@@ -57,7 +57,7 @@ class CustomExportToOnnx(torch.autograd.Function):
         return cls.apply(*args)
 
     @staticmethod
-    def forward(ctx: Any, *args: Any, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
+    def forward(*args: Any, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
         """Applies custom forward function."""
         if CustomExportToOnnx._NEXT_FORWARD_FUNCTION is None:
             raise RuntimeError('Forward function is not set')

--- a/tests/node_converters/registry_test.py
+++ b/tests/node_converters/registry_test.py
@@ -1,0 +1,32 @@
+import pytest
+
+from onnx2torch2.node_converters.registry import add_converter, get_converter
+
+from onnx2torch2.node_converters.nms import OnnxNonMaxSuppression
+from onnx2torch2.onnx_graph import OnnxGraph
+from onnx2torch2.onnx_node import OnnxNode
+from onnx2torch2.utils.common import OperationConverterResult
+from onnx2torch2.utils.common import onnx_mapping_from_node
+
+
+def _register(override_registry: bool = False) -> None:
+    @add_converter(operation_type='NonMaxSuppression', version=10, override_registry=override_registry)
+    @add_converter(operation_type='NonMaxSuppression', version=11, override_registry=override_registry)
+    def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: disable=unused-argument
+        center_point_box = node.attributes.get('center_point_box', 0)
+        return OperationConverterResult(
+            torch_module=OnnxNonMaxSuppression(center_point_box=center_point_box),
+            onnx_mapping=onnx_mapping_from_node(node),
+        )
+
+def test_registry_override() -> None:
+    # prove that converter is already registered
+    assert get_converter("NonMaxSuppression", version=10) is not None
+    assert get_converter("NonMaxSuppression", version=11) is not None
+
+    # prove that we cannot override register without passing flag
+    with pytest.raises(ValueError, match="already registered"):
+        _register()
+
+    # can only override with flag set
+    _register(override_registry=True)

--- a/tests/node_converters/registry_test.py
+++ b/tests/node_converters/registry_test.py
@@ -19,6 +19,7 @@ def _register(override_registry: bool = False) -> None:
             onnx_mapping=onnx_mapping_from_node(node),
         )
 
+
 def test_registry_override() -> None:
     # prove that converter is already registered
     assert get_converter("NonMaxSuppression", version=10) is not None

--- a/tests/node_converters/registry_test.py
+++ b/tests/node_converters/registry_test.py
@@ -1,8 +1,8 @@
 import pytest
 
-from onnx2torch2.node_converters.registry import add_converter, get_converter
-
 from onnx2torch2.node_converters.nms import OnnxNonMaxSuppression
+from onnx2torch2.node_converters.registry import add_converter
+from onnx2torch2.node_converters.registry import get_converter
 from onnx2torch2.onnx_graph import OnnxGraph
 from onnx2torch2.onnx_node import OnnxNode
 from onnx2torch2.utils.common import OperationConverterResult


### PR DESCRIPTION
Currently once a converter has been registered it cannot be overridden. It might be desirable to allow overriding registered converters, i.e, if a user wishes to register a customer converter.

This PR introduces the ability to override and replace the registered converter if a new flag is set in the `@add_converter` decorator.

A test case has been added to demonstrate the functionality.