### PR TITLE
handle Pad where padding arg is node with no value

### DIFF
--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -126,7 +126,7 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         # try and get padding value from node, or set as None
         try:
             pads = get_const_value(pads_name, graph).tolist()
-        except:
+        except KeyError:
             pads = None
 
     return OperationConverterResult(

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -128,8 +128,8 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
             pads = get_const_value(pads_name, graph).tolist()
         except KeyError as e:
             raise (
-                f"Dynamic padding is not supported. Pad node `{node.name}` 
-                has padding arg `{pads_name}` with no static value. Error: {e}"
+                f"Dynamic padding is not supported. Pad node `{node.name}`"\
+                    "has padding arg `{pads_name}` with no static value. Error: {e}"
             )
 
     return OperationConverterResult(

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -120,13 +120,13 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     mode = node.attributes.get('mode', 'constant')
     mode = _onnx_to_torch_mode(mode)
 
-    pads_name = node.input_values[1] # get name of padding node (see onnx Pad documentation for index)
+    pads_name = node.input_values[1]
     pads = []
     if pads_name in graph.initializers or pads_name in graph._node_output_values:  # pylint: disable=W0212
         # try and get padding value from node, or set as None
         try:
             pads = get_const_value(pads_name, graph).tolist()
-        except Exception as e:
+        except:
             pads = None
 
     return OperationConverterResult(

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -123,11 +123,11 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     pads_name = node.input_values[1]
     pads = []
     if pads_name in graph.initializers or pads_name in graph._node_output_values:  # pylint: disable=W0212
-        # try and get padding value from node, or set as None
+        # try and get padding value frpads = Noneom node, or set as None
         try:
             pads = get_const_value(pads_name, graph).tolist()
-        except KeyError:
-            pads = None
+        except KeyError as e:
+            raise f"Dynamic padding is not supported. Pad node `{node.name}` has padding arg `{pads_name}` with no static value. Error: {e}"
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -126,11 +126,11 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         # try and get padding arg value
         try:
             pads = get_const_value(pads_name, graph).tolist()
-        except KeyError:
+        except KeyError as exc:
             raise ValueError(
                 f"Dynamic padding is not supported. Pad node `{node.name}`"
                 f"has padding arg `{pads_name}` with no static value."
-            )
+            ) from exc
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -126,11 +126,10 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         # try and get padding arg value
         try:
             pads = get_const_value(pads_name, graph).tolist()
-        except KeyError as e:
+        except KeyError:
             raise ValueError(
                 f"Dynamic padding is not supported. Pad node `{node.name}`"
-                f"has padding arg `{pads_name}` with no static value. Error: {e}"
-            ) from e
+                f"has padding arg `{pads_name}` with no static value.")
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -127,9 +127,9 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         try:
             pads = get_const_value(pads_name, graph).tolist()
         except KeyError as e:
-            raise (
+            raise ValueError(
                 f"Dynamic padding is not supported. Pad node `{node.name}`"\
-                    "has padding arg `{pads_name}` with no static value. Error: {e}"
+                    f"has padding arg `{pads_name}` with no static value. Error: {e}"
             )
 
     return OperationConverterResult(

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -120,10 +120,14 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     mode = node.attributes.get('mode', 'constant')
     mode = _onnx_to_torch_mode(mode)
 
-    pads_name = node.input_values[1]
+    pads_name = node.input_values[1] # get name of padding node (see onnx Pad documentation for index)
     pads = []
     if pads_name in graph.initializers or pads_name in graph._node_output_values:  # pylint: disable=W0212
-        pads = get_const_value(pads_name, graph).tolist()
+        # try and get padding value from node, or set as None
+        try:
+            pads = get_const_value(pads_name, graph).tolist()
+        except Exception as e:
+            pads = None
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -129,7 +129,8 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         except KeyError:
             raise ValueError(
                 f"Dynamic padding is not supported. Pad node `{node.name}`"
-                f"has padding arg `{pads_name}` with no static value.")
+                f"has padding arg `{pads_name}` with no static value."
+            )
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -127,7 +127,10 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         try:
             pads = get_const_value(pads_name, graph).tolist()
         except KeyError as e:
-            raise f"Dynamic padding is not supported. Pad node `{node.name}` has padding arg `{pads_name}` with no static value. Error: {e}"
+            raise (
+                f"Dynamic padding is not supported. Pad node `{node.name}` 
+                has padding arg `{pads_name}` with no static value. Error: {e}"
+            )
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -129,7 +129,7 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
         except KeyError as e:
             raise ValueError(
                 f"Dynamic padding is not supported. Pad node `{node.name}`"\
-                    f"has padding arg `{pads_name}` with no static value. Error: {e}"
+                f"has padding arg `{pads_name}` with no static value. Error: {e}"
             ) from e
 
     return OperationConverterResult(

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -123,7 +123,7 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
     pads_name = node.input_values[1]
     pads = []
     if pads_name in graph.initializers or pads_name in graph._node_output_values:  # pylint: disable=W0212
-        # try and get padding value frpads = Noneom node, or set as None
+        # try and get padding arg value
         try:
             pads = get_const_value(pads_name, graph).tolist()
         except KeyError as e:

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -128,7 +128,7 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
             pads = get_const_value(pads_name, graph).tolist()
         except KeyError as e:
             raise ValueError(
-                f"Dynamic padding is not supported. Pad node `{node.name}`"\
+                f"Dynamic padding is not supported. Pad node `{node.name}`"
                 f"has padding arg `{pads_name}` with no static value. Error: {e}"
             ) from e
 

--- a/onnx2torch2/node_converters/pad.py
+++ b/onnx2torch2/node_converters/pad.py
@@ -130,7 +130,7 @@ def _(node: OnnxNode, graph: OnnxGraph) -> OperationConverterResult:  # pylint: 
             raise ValueError(
                 f"Dynamic padding is not supported. Pad node `{node.name}`"\
                     f"has padding arg `{pads_name}` with no static value. Error: {e}"
-            )
+            ) from e
 
     return OperationConverterResult(
         torch_module=OnnxPadDynamic(pads=pads, mode=mode),


### PR DESCRIPTION


Pad node has a `pads` argument at pad_node.input_values[1] (see [onnx documentation)](https://onnx.ai/onnx/operators/onnx__Pad.html) . 

If it is a node, `get_const_value` gets the value of the node by checking `node.attributes["value"]`. However, some models may have a padding argument where `node.attributes["value"]` does not exist. This causes the `get_const_value` to raise a KeyError: Tensor {name} is not found in constant values.

Fix: 
Add try except block to set padding as None if could not get constant value from the `pads` argument node.