### PR TITLE
update scatterND to support torch-2.5.1

### DIFF
--- a/onnx2torch2/node_converters/scatter_nd.py
+++ b/onnx2torch2/node_converters/scatter_nd.py
@@ -67,7 +67,7 @@ class OnnxScatterND(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: di
         def _forward():
             # There is no scatter nd for torch, use following formula:
             # https://github.com/onnx/onnx/blob/master/docs/Operators.md#ScatterND
-            output = torch.tensor(data.clone(), device=data.device)
+            output = data.clone()  # to avoid RuntimeError: cannot mutate tensors with frozen storage
             ind_dim = indices.dim()
             # last dimension is a partial-index into data
             output_indices = torch.split(torch.t(indices.reshape((-1, indices.shape[-1]))), 1)
@@ -75,7 +75,7 @@ class OnnxScatterND(nn.Module, OnnxToTorchModuleWithCustomExport):  # pylint: di
             output_updates = updates.reshape((-1, *updates.shape[ind_dim - 1 :]))
             output[output_indices] = output_updates
 
-            return output
+            return output.to(data.device)
 
         if torch.onnx.is_in_onnx_export():
             onnx_attrs = self._onnx_attrs(opset_version=get_onnx_version())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'onnx2torch2'
-version = '2.1.1'
+version = '2.1.0'
 license = {file = 'LICENSE'}
 description = 'ONNX to PyTorch converter'
 readme = {file = 'README.md', content-type = 'text/markdown'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'onnx2torch2'
-version = '2.1.0'
+version = '2.1.1'
 license = {file = 'LICENSE'}
 description = 'ONNX to PyTorch converter'
 readme = {file = 'README.md', content-type = 'text/markdown'}


### PR DESCRIPTION
This PR 
- updates scatterND's `clone` to support torch-2.5.1