### PR TITLE
Fix Safe Shape for Large Models

### DIFF
--- a/onnx2torch2/utils/safe_shape_inference.py
+++ b/onnx2torch2/utils/safe_shape_inference.py
@@ -39,6 +39,7 @@ def safe_shape_inference(  # pylint: disable=missing-function-docstring
                 f=str(tmp_model_path),
                 save_as_external_data=True,
                 all_tensors_to_one_file=True,
+                convert_attribute=True,
             )
             return _shape_inference_by_model_path(tmp_model_path, output_path=tmp_model_path, **kwargs)
 


### PR DESCRIPTION
Onnx models of over 2GB can't be saved without setting the arg `convert_attribute=True`, adding the line to support larger models.